### PR TITLE
fix: Updated feeds api - removed content from feed api

### DIFF
--- a/src/server/router/_app.ts
+++ b/src/server/router/_app.ts
@@ -16,7 +16,7 @@ export const appRouter = router({
   feed: procedure.query(async ({ input }) => {
     const response = await supabaseAdminClient
       .from("posts")
-      .select("*")
+      .select("id", "preview_content", "lock_address", "lock_network", "author_address", "is_published", "updated_at", "created_at")
       .order("updated_at", { ascending: false })
       .filter("is_published", "eq", true)
       .limit(100);

--- a/src/server/router/_app.ts
+++ b/src/server/router/_app.ts
@@ -167,7 +167,7 @@ export const appRouter = router({
     .query(async ({ input: { address } }) => {
       const response = await supabaseAdminClient
         .from("posts")
-        .select("*")
+        .select("id", "preview_content", "lock_address", "lock_network", "author_address", "is_published", "updated_at", "created_at")
         .eq("is_published", true)
         .eq("author_address", address)
         .order("updated_at", { ascending: false })


### PR DESCRIPTION
I have updated the feed API to return all data except the content.

The current implementation allows non-holders to access the content (feeds API exposes the content on homepage).